### PR TITLE
Allows messages to be maps with string keys

### DIFF
--- a/test/broadway_cloud_pub_sub/google_api_client_test.exs
+++ b/test/broadway_cloud_pub_sub/google_api_client_test.exs
@@ -286,6 +286,36 @@ defmodule BroadwayCloudPubSub.GoogleApiClientTest do
     end
   end
 
+  describe "wrap_received_messages/2" do
+    test "allows string keys for messages" do
+      message = %{
+        "ackId" => "THE ACK ID",
+        "message" => %{
+          "attributes" => %{"space" => "vegans"},
+          "data" => "VEhJUyBJUyBBIFRFU1Q=",
+          "messageId" => "111110000222233344",
+          "publishTime" => "2019-09-05T17:41:31.520Z"
+        }
+      }
+
+      messages = {:ok, %{receivedMessages: [message]}}
+
+      result = [
+        %Broadway.Message{
+          acknowledger: {BroadwayCloudPubSub.GoogleApiClient, "Ack Ref", "THE ACK ID"},
+          batch_key: :default,
+          batch_mode: :bulk,
+          batcher: :default,
+          data: "THIS IS A TEST",
+          metadata: %{},
+          status: :ok
+        }
+      ]
+
+      assert GoogleApiClient.wrap_received_messages(messages, "Ack Ref") == result
+    end
+  end
+
   describe "ack/2" do
     setup do
       test_pid = self()


### PR DESCRIPTION
For some reason that I can't figure out, when querying Pub Sub in
production, line 71 in GoogleApiClient the pubsub_projects_subscriptions_pull/3
returns me something that looks like this:

```elixir
 {:ok,
 %GoogleApi.PubSub.V1.Model.PullResponse{
   receivedMessages: [
     %{
       "ackId" => "ID",
       "message" => %{
         "attributes" => %{"space" => "vegans"},
         "data" => "VEhJUyBJUyBBIFRFU1Q=",
         "messageId" => "1234321",
         "publishTime" => "2019-09-05T17:41:31.520Z"
       }
     }
   ]
 }}
```

However I notice when I run the tests here the same function returns me:

```elixir
{:ok,
 %GoogleApi.PubSub.V1.Model.PullResponse{
   receivedMessages: [
     %GoogleApi.PubSub.V1.Model.ReceivedMessage{
       ackId: "ACK ID",
       message: %GoogleApi.PubSub.V1.Model.PubsubMessage{
         attributes: %{"space" => "vegans"},
         data: "VEhJUyBJUyBBIFRFU1Q=",
         messageId: "708601755676243",
         publishTime: ~U[2019-09-05 17:41:31.520Z]
       }
     }
   ]
 }}
```

This allows me to continue even though my response from Pub Sub is not
getting serialized into a GoogleApi.PubSub.V1.Model.ReceivedMessage